### PR TITLE
Fix checkout en nginx

### DIFF
--- a/culqi-woocommerce.php
+++ b/culqi-woocommerce.php
@@ -448,7 +448,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
                                 $('#info_payment').waitMe('hide');
                             });
                             $.ajax({
-                                url: "index.php?wc-api=WC_culqi",
+                                url: "?wc-api=WC_culqi",
                                 type: "POST",
                                 data: {token_id: Culqi.token.id, order_id: "<?php echo $numeroPedido ?>", installments: Culqi.token.metadata.installments },
                                 dataType: 'json',


### PR DESCRIPTION
Cuando un sitio wordpress está hospedado en nginx (no apache), la configuración recomendada de Wordpress no permite manejar el link `/checkout/index.php?wc-api=WC_culqi` dado que el archivo `index.php` no existe. Nginx retorna error 404.

La carpeta `/checkout/` es solo lógica, no existe en el sistema de archivos, y es manejada por permalinks, por tanto, el submit debería ocurrir en `/checkout?wc-api=WC_culqi` y no en `/checkout/index.php?wc-api=WC_culqi`