### PR TITLE
Compatibilidad con nuevo bloque checkout woocommerce

### DIFF
--- a/assets/gateway.js
+++ b/assets/gateway.js
@@ -13,7 +13,7 @@
 
 jQuery(function ($) {
     $('form.checkout').on('checkout_place_order', function (e) {
-        var paymentGateway = jQuery('input[name="payment_method"]:checked').val();
+        const paymentGateway = jQuery('input[name="payment_method"]:checked').val();
 
         if (paymentGateway !== 'culqi') {
             return true; // dejar que otros gateways funcionen normal
@@ -65,7 +65,7 @@ jQuery(function ($) {
 // Habilitar botón cuando el checkout clásico termina de cargar
 jQuery(function ($) {
     $(document.body).on('updated_checkout', function () {
-        var checkoutIsReady = function () {
+        const checkoutIsReady = function () {
             return (
                 $('#place_order').length &&
                 $('.woocommerce-checkout').length &&
@@ -73,10 +73,10 @@ jQuery(function ($) {
             );
         };
 
-        var maxAttempts = 10;
-        var attempts    = 0;
+        const maxAttempts = 10;
+        let attempts     = 0;
 
-        var checkReadyState = setInterval(function () {
+        const checkReadyState = setInterval(function () {
             attempts++;
 
             if (checkoutIsReady()) {
@@ -135,7 +135,7 @@ window.addEventListener(
 );
 
 function customRedirect() {
-    var redirectUrl = window.redirectUrl;
+    const redirectUrl = window.redirectUrl;
     delete window.redirectUrl;
     window.location.href = redirectUrl;
 }
@@ -144,7 +144,7 @@ function showWooCommerceError(htmlContent) {
     jQuery('.wc-block-components-notice-banner').remove();
     jQuery('#culqi-checkout-error').remove();
 
-    var errorContainer = jQuery('<div id="culqi-checkout-error"></div>');
+    const errorContainer = jQuery('<div id="culqi-checkout-error"></div>');
     errorContainer.html(htmlContent);
 
     // Funciona en classic checkout. En block checkout los errores

--- a/assets/gateway.js
+++ b/assets/gateway.js
@@ -1,96 +1,88 @@
-jQuery(function($) {
-    const operationProcessing = 'processing';
-    $('form.checkout').on('checkout_place_order', function(e) {
-        const paymentGateway = jQuery('input[name="payment_method"]:checked').val();
-        if(paymentGateway === 'culqi') {
-            $('.woocommerce-loader').addClass('flex');
-            jQuery('#place_order').attr('disabled', true);
-            e.preventDefault();
+/**
+ * Culqi — gateway.js
+ *
+ * Maneja el flujo de pago del checkout CLÁSICO (shortcode).
+ * También contiene el listener de postMessage del iframe de Culqi,
+ * que funciona para AMBOS checkouts (clásico y block) porque este
+ * script se carga en todas las páginas de checkout via gateway-scripts.php.
+ *
+ * NO usar jQuery para el block checkout — ese flujo lo maneja culqi-block.js.
+ *
+ * @package Culqi
+ */
 
-            $.ajax({
-                type: 'POST',
-                url: wc_checkout_params.checkout_url,
-                data: $('form.checkout').serialize(),
-                success: function(response) {
-                    if (response.result === 'success') {
-                        if(response.show_modal) {
-                            $('#order-created-modal').fadeIn();
-                            $('#order-created-modal iframe').attr('src', response.redirect);
-                            $('body').addClass('no-scroll');
-                            // $('.woocommerce-loader').removeClass('flex');
-                        } else {
-                            window.location.href = response.redirect;
-                        }
-                        jQuery('#place_order').attr('disabled', false);
+jQuery(function ($) {
+    $('form.checkout').on('checkout_place_order', function (e) {
+        var paymentGateway = jQuery('input[name="payment_method"]:checked').val();
+
+        if (paymentGateway !== 'culqi') {
+            return true; // dejar que otros gateways funcionen normal
+        }
+
+        $('.woocommerce-loader').addClass('flex');
+        jQuery('#place_order').attr('disabled', true);
+        e.preventDefault();
+
+        $.ajax({
+            type:    'POST',
+            url:     wc_checkout_params.checkout_url,
+            data:    $('form.checkout').serialize(),
+            success: function (response) {
+                if (response.result === 'success') {
+                    if (response.show_modal) {
+                        // Abrir iframe modal con la URL de Culqi
+                        $('#order-created-modal').fadeIn();
+                        $('#order-created-modal iframe').attr('src', response.redirect);
+                        $('body').addClass('no-scroll');
                     } else {
-                        if (response.messages) {
-                            showWooCommerceError(response.messages);
-                        } else {
-                            showWooCommerceError('Order creation failed. Please try again.');
-                        }
-                        $('.woocommerce-loader').fadeOut();
-                        $('.woocommerce-loader').removeClass('flex');
-                        jQuery('#place_order').attr('disabled', false);
+                        window.location.href = response.redirect;
                     }
-                },
-                error: function(err) {
-                    showWooCommerceError('Error while creating order. Please try again.');
-                    console.log(err);
+                    jQuery('#place_order').attr('disabled', false);
+                } else {
+                    if (response.messages) {
+                        showWooCommerceError(response.messages);
+                    } else {
+                        showWooCommerceError('Order creation failed. Please try again.');
+                    }
                     $('.woocommerce-loader').fadeOut();
                     $('.woocommerce-loader').removeClass('flex');
                     jQuery('#place_order').attr('disabled', false);
                 }
-            });
+            },
+            error: function (err) {
+                showWooCommerceError('Error while creating order. Please try again.');
+                console.log(err);
+                $('.woocommerce-loader').fadeOut();
+                $('.woocommerce-loader').removeClass('flex');
+                jQuery('#place_order').attr('disabled', false);
+            },
+        });
 
-            return false;
-        }
+        return false;
     });
-
-    window.addEventListener('message', function(event) {
-        if (event.data.object == "appCulqiStoreLoaded") {
-            $('.woocommerce-loader').removeClass('flex');
-        }
-        if (event.data.redirectUrl) {
-            window.redirectUrl = event.data.redirectUrl;
-        }
-        if (event.data.operationType == operationProcessing) {
-            if (window.redirectUrl) {
-                customRedirect();
-            }
-        }
-        if (event.data.action === 'closeModal') {
-            $('#order-created-modal').fadeOut();
-            $('body').removeClass('no-scroll');
-            $('.woocommerce-loader').removeClass('flex');
-            if (window.redirectUrl) {
-                customRedirect();
-            }
-        }
-    }, false);
 });
 
-jQuery(function($) {
-    $(document.body).on('updated_checkout', function() {
-        const checkoutIsReady = function() {
+// Habilitar botón cuando el checkout clásico termina de cargar
+jQuery(function ($) {
+    $(document.body).on('updated_checkout', function () {
+        var checkoutIsReady = function () {
             return (
                 $('#place_order').length &&
                 $('.woocommerce-checkout').length &&
-                (typeof wc_checkout_params !== 'undefined') &&
-                (typeof Culqi === 'undefined' || Culqi.options)
+                typeof wc_checkout_params !== 'undefined'
             );
         };
 
-        const maxAttempts = 10;
-        let attempts = 0;
+        var maxAttempts = 10;
+        var attempts    = 0;
 
-        const checkReadyState = setInterval(function() {
+        var checkReadyState = setInterval(function () {
             attempts++;
 
             if (checkoutIsReady()) {
                 clearInterval(checkReadyState);
                 enableButton();
-            }
-            else if (attempts >= maxAttempts) {
+            } else if (attempts >= maxAttempts) {
                 clearInterval(checkReadyState);
                 console.warn('Checkout elements not fully loaded after attempts');
                 $('#place_order').prop('disabled', false);
@@ -100,28 +92,50 @@ jQuery(function($) {
 });
 
 function enableButton() {
-    console.log('Checkout fully loaded');
     jQuery('#place_order').prop('disabled', false);
 }
 
-document.addEventListener('DOMContentLoaded', function () {
-    // Check if WooCommerce Blocks is initialized
-    if (typeof wp !== 'undefined' && wp.data && wp.data.dispatch) {
-        // Check if wc/store is available in wp.data
-        const store = wp.data.dispatch('wc/store');
-
-        if (store) {
-            console.log('WooCommerce Blocks is initialized and wc/store is available.');
-        } else {
-            console.error('WooCommerce Blocks is not initialized or wc/store is not available.');
+// postMessage listener — compartido por Classic y Block Checkout
+//
+// El iframe de Culqi envía mensajes via postMessage para comunicar eventos:
+//   - appCulqiStoreLoaded: el iframe cargó, ocultar el loader
+//   - redirectUrl:         URL a la que redirigir después del pago
+//   - operationType=processing: el pago está en procesamiento, redirigir
+//   - action=closeModal:   el usuario cerró el modal de Culqi
+//
+// Este listener funciona en ambos checkouts porque gateway.js se carga en
+// todas las páginas de checkout (wp_enqueue_scripts + is_checkout()).
+window.addEventListener(
+    'message',
+    function (event) {
+        if (event.data.object === 'appCulqiStoreLoaded') {
+            jQuery('.woocommerce-loader').removeClass('flex');
         }
-    } else {
-        console.error('WooCommerce Blocks or wp.data is not loaded.');
-    }
-});
+
+        if (event.data.redirectUrl) {
+            window.redirectUrl = event.data.redirectUrl;
+        }
+
+        if (event.data.operationType === 'processing') {
+            if (window.redirectUrl) {
+                customRedirect();
+            }
+        }
+
+        if (event.data.action === 'closeModal') {
+            jQuery('#order-created-modal').fadeOut();
+            jQuery('body').removeClass('no-scroll');
+            jQuery('.woocommerce-loader').removeClass('flex');
+            if (window.redirectUrl) {
+                customRedirect();
+            }
+        }
+    },
+    false
+);
 
 function customRedirect() {
-    const redirectUrl = window.redirectUrl;
+    var redirectUrl = window.redirectUrl;
     delete window.redirectUrl;
     window.location.href = redirectUrl;
 }
@@ -130,17 +144,20 @@ function showWooCommerceError(htmlContent) {
     jQuery('.wc-block-components-notice-banner').remove();
     jQuery('#culqi-checkout-error').remove();
 
-    const errorContainer = jQuery('<div id="culqi-checkout-error"></div>');
+    var errorContainer = jQuery('<div id="culqi-checkout-error"></div>');
     errorContainer.html(htmlContent);
 
+    // Funciona en classic checkout. En block checkout los errores
+    // los maneja el propio block via emitResponse.responseTypes.ERROR.
     jQuery('form.checkout').prepend(errorContainer);
 
-    jQuery('html, body').animate({
-        scrollTop: errorContainer.offset().top - 100
-    }, 300);
+    jQuery('html, body').animate(
+        { scrollTop: errorContainer.offset().top - 100 },
+        300
+    );
 
-    setTimeout(() => {
-        errorContainer.fadeOut(300, function() {
+    setTimeout(function () {
+        errorContainer.fadeOut(300, function () {
             jQuery(this).remove();
         });
     }, 10000);

--- a/assets/js/culqi-block.js
+++ b/assets/js/culqi-block.js
@@ -1,25 +1,185 @@
+/**
+ * Culqi — integración con el WooCommerce Block Checkout.
+ *
+ * @package Culqi
+ */
 
-const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
+(function () {
+    'use strict';
 
-    const options = {
-        name: 'culqi',
-        title: 'Culqi',
-        description: 'A setence or two about your payment method',
-        gatewayId: 'culqi',
-        label: 'Culqi',
-        ariaLabel: 'Culqi',
-        content: wp.element.createElement('div', null, 'Paga con Culqi'),
-        edit: wp.element.createElement('div', null, 'Edit your payment method here'),
-        canMakePayment: () => {
+    var registerPaymentMethod = window.wc.wcBlocksRegistry.registerPaymentMethod;
+    var getSetting            = window.wc.wcSettings.getSetting;
+    var createElement         = window.wp.element.createElement;
+    var useEffect             = window.wp.element.useEffect;
+    var decodeEntities        = window.wp.htmlEntities.decodeEntities;
+
+    var settings    = getSetting('culqi_data', {});
+    var label       = decodeEntities(settings.title || 'Culqi');
+    var description = decodeEntities(settings.description || '');
+    var icons       = settings.icons || [];
+    var logoUrl     = settings.logo_url || '';
+
+    function abrirModalCulqi(url) {
+        var modal  = document.getElementById('order-created-modal');
+        var iframe = modal && modal.querySelector('iframe');
+
+        if (!modal || !iframe) {
+            console.error('[Culqi Block] Modal #order-created-modal no encontrado. Redirigiendo...');
+            window.location.href = url;
+            return;
+        }
+
+        iframe.src = url;
+        modal.style.display = 'flex';
+        document.body.classList.add('no-scroll');
+    }
+
+    function CulqiLabel(props) {
+        var PaymentMethodLabel = props.components.PaymentMethodLabel;
+
+        return createElement(
+            'span',
+            {
+                style: {
+                    display:        'flex',
+                    alignItems:     'center',
+                    justifyContent: 'space-between',
+                    width:          '100%',
+                },
+            },
+            createElement(
+                'span',
+                { style: { display: 'flex', alignItems: 'center', gap: '6px' } },
+                logoUrl
+                    ? createElement('img', {
+                        src:   logoUrl,
+                        alt:   'Culqi',
+                        style: { height: '22px', verticalAlign: 'middle' },
+                      })
+                    : null,
+                createElement(PaymentMethodLabel, { text: label })
+            ),
+            icons.length > 0
+                ? createElement(
+                    'span',
+                    { style: { display: 'flex', alignItems: 'center', gap: '4px' } },
+                    icons.map(function (icon) {
+                        return createElement('img', {
+                            key:   icon.id,
+                            src:   icon.src,
+                            alt:   icon.alt,
+                            style: { height: '22px' },
+                        });
+                    })
+                  )
+                : null
+        );
+    }
+
+    function CulqiContent(props) {
+        var eventRegistration           = props.eventRegistration;
+        var emitResponse                = props.emitResponse;
+        var onPaymentSetup              = eventRegistration.onPaymentSetup;
+        var onAfterProcessingWithSuccess = eventRegistration.onCheckoutAfterProcessingWithSuccess;
+
+        useEffect(function () {
+            var unsubscribe = onPaymentSetup(function () {
+                return {
+                    type: emitResponse.responseTypes.SUCCESS,
+                    meta: {
+                        paymentMethodData: {
+                            culqi_checkout_type: 'block',
+                        },
+                    },
+                };
+            });
+
+            return unsubscribe;
+        }, [onPaymentSetup, emitResponse.responseTypes.SUCCESS]);
+
+        useEffect(function () {
+            var unsubscribe = onAfterProcessingWithSuccess(function (checkoutResponse) {
+                var redirectUrl = checkoutResponse && checkoutResponse.redirectUrl;
+                var orderId     = checkoutResponse && checkoutResponse.orderId;
+
+                // Fallback: si hay redirectUrl (puede llegar del Store API)
+                if (redirectUrl && redirectUrl !== window.location.href) {
+                    try {
+                        var parsed = new URL(redirectUrl);
+                        if (
+                            parsed.hostname.indexOf('culqi.com') !== -1 ||
+                            parsed.hostname.indexOf('nonprodculqi.com') !== -1
+                        ) {
+                            abrirModalCulqi(redirectUrl);
+                            return { type: emitResponse.responseTypes.SUCCESS };
+                        }
+                    } catch (e) {
+                        console.warn('[Culqi Block] redirect_url inválida:', redirectUrl);
+                    }
+                }
+
+                // Flujo principal: sin redirect, obtener URL via REST
+                if (orderId) {
+                    var url = settings.ajax_url + '?order_id=' + orderId;
+                    fetch(url)
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (data && data.url) {
+                                abrirModalCulqi(data.url);
+                            } else {
+                                console.error('[Culqi Block] No se obtuvo URL de pago');
+                            }
+                        })
+                        .catch(function (err) {
+                            console.error('[Culqi Block] Error al obtener URL de pago:', err);
+                        });
+                }
+
+                return { type: emitResponse.responseTypes.SUCCESS };
+            });
+
+            return unsubscribe;
+        }, [onAfterProcessingWithSuccess, emitResponse.responseTypes.SUCCESS]);
+
+        return createElement(
+            'div',
+            { className: 'wc-culqi-block-content' },
+            description
+                ? createElement('p', { style: { margin: '8px 0 0', fontSize: '14px' } }, description)
+                : null
+        );
+    }
+
+    // Componente: Edit (preview en el editor de Gutenberg)
+
+    function CulqiEdit() {
+        return createElement(
+            'div',
+            { style: { padding: '8px', fontSize: '13px', color: '#777' } },
+            description || 'Culqi — tarjetas, Yape, PagoEfectivo'
+        );
+    }
+
+    // Registro del método de pago
+
+    registerPaymentMethod({
+        name:    'culqi',
+
+        label:   createElement(CulqiLabel, null),
+
+        content: createElement(CulqiContent, null),
+
+        edit:    createElement(CulqiEdit, null),
+
+        ariaLabel: label,
+
+        canMakePayment: function () {
             return true;
+        },
 
-        },
-        paymentMethodId: 'culqi',
         supports: {
-            features: ['default', 'products', 'subscriptions'],
-            style: [],
+            features: settings.supports || ['products'],
         },
-        method_title: 'Culqi',
-        method_description: 'A sentence or two about your payment method',
-    };
-    registerPaymentMethod(options);     
+    });
+
+})();

--- a/assets/js/culqi-block.js
+++ b/assets/js/culqi-block.js
@@ -7,21 +7,21 @@
 (function () {
     'use strict';
 
-    var registerPaymentMethod = window.wc.wcBlocksRegistry.registerPaymentMethod;
-    var getSetting            = window.wc.wcSettings.getSetting;
-    var createElement         = window.wp.element.createElement;
-    var useEffect             = window.wp.element.useEffect;
-    var decodeEntities        = window.wp.htmlEntities.decodeEntities;
+    const registerPaymentMethod = window.wc.wcBlocksRegistry.registerPaymentMethod;
+    const getSetting            = window.wc.wcSettings.getSetting;
+    const createElement         = window.wp.element.createElement;
+    const useEffect             = window.wp.element.useEffect;
+    const decodeEntities        = window.wp.htmlEntities.decodeEntities;
 
-    var settings    = getSetting('culqi_data', {});
-    var label       = decodeEntities(settings.title || 'Culqi');
-    var description = decodeEntities(settings.description || '');
-    var icons       = settings.icons || [];
-    var logoUrl     = settings.logo_url || '';
+    const settings    = getSetting('culqi_data', {});
+    const label       = decodeEntities(settings.title || 'Culqi');
+    const description = decodeEntities(settings.description || '');
+    const icons       = settings.icons || [];
+    const logoUrl     = settings.logo_url || '';
 
     function abrirModalCulqi(url) {
-        var modal  = document.getElementById('order-created-modal');
-        var iframe = modal && modal.querySelector('iframe');
+        const modal  = document.getElementById('order-created-modal');
+        const iframe = modal && modal.querySelector('iframe');
 
         if (!modal || !iframe) {
             console.error('[Culqi Block] Modal #order-created-modal no encontrado. Redirigiendo...');
@@ -35,7 +35,7 @@
     }
 
     function CulqiLabel(props) {
-        var PaymentMethodLabel = props.components.PaymentMethodLabel;
+        const PaymentMethodLabel = props.components.PaymentMethodLabel;
 
         return createElement(
             'span',
@@ -77,13 +77,13 @@
     }
 
     function CulqiContent(props) {
-        var eventRegistration           = props.eventRegistration;
-        var emitResponse                = props.emitResponse;
-        var onPaymentSetup              = eventRegistration.onPaymentSetup;
-        var onAfterProcessingWithSuccess = eventRegistration.onCheckoutAfterProcessingWithSuccess;
+        const eventRegistration           = props.eventRegistration;
+        const emitResponse                = props.emitResponse;
+        const onPaymentSetup              = eventRegistration.onPaymentSetup;
+        const onAfterProcessingWithSuccess = eventRegistration.onCheckoutAfterProcessingWithSuccess;
 
         useEffect(function () {
-            var unsubscribe = onPaymentSetup(function () {
+            const unsubscribe = onPaymentSetup(function () {
                 return {
                     type: emitResponse.responseTypes.SUCCESS,
                     meta: {
@@ -98,14 +98,14 @@
         }, [onPaymentSetup, emitResponse.responseTypes.SUCCESS]);
 
         useEffect(function () {
-            var unsubscribe = onAfterProcessingWithSuccess(function (checkoutResponse) {
-                var redirectUrl = checkoutResponse && checkoutResponse.redirectUrl;
-                var orderId     = checkoutResponse && checkoutResponse.orderId;
+            const unsubscribe = onAfterProcessingWithSuccess(function (checkoutResponse) {
+                const redirectUrl = checkoutResponse && checkoutResponse.redirectUrl;
+                const orderId     = checkoutResponse && checkoutResponse.orderId;
 
                 // Fallback: si hay redirectUrl (puede llegar del Store API)
                 if (redirectUrl && redirectUrl !== window.location.href) {
                     try {
-                        var parsed = new URL(redirectUrl);
+                        const parsed = new URL(redirectUrl);
                         if (
                             parsed.hostname.indexOf('culqi.com') !== -1 ||
                             parsed.hostname.indexOf('nonprodculqi.com') !== -1
@@ -120,7 +120,7 @@
 
                 // Flujo principal: sin redirect, obtener URL via REST
                 if (orderId) {
-                    var url = settings.ajax_url + '?order_id=' + orderId;
+                    const url = settings.ajax_url + '?order_id=' + orderId;
                     fetch(url)
                         .then(function (r) { return r.json(); })
                         .then(function (data) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+2026-06-15 - version 4.1.0
+Feature: Full compatibility with WooCommerce Block Checkout (Cart/Checkout Blocks)
+Feature: Dynamic payment method icons (cards, Yape, PagoEfectivo) in block checkout
+Feature: REST API endpoint to retrieve payment URL from order meta for block checkout flow
+Feature: iframe payment modal now works on both classic and block checkout
+Refactor: Separate classic and block checkout logic in gateway.js
+Refactor: Culqi_Integration now extends AbstractPaymentMethodType properly
+Refactor: Remove duplicate block script enqueue; now handled exclusively by payment method registry
+
 2026-04-13 - version 4.0.1
 Feature: Add logger for payment activity tracking
 Feature: Show friendly error message when payment fails

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
-        "phpseclib/phpseclib": "^3.0",
-        "firebase/php-jwt": "6.10.0"
+        "phpseclib/phpseclib": "3.0.52",
+        "firebase/php-jwt": "^7.0"
     },
     "require-dev": {
         "php-stubs/wordpress-stubs": "^6.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c0ed094c51f2f8f8d872f5b237df70b",
+    "content-hash": "0fe186a038f419ec288a9e9e7ca8a7fd",
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.10.0",
+            "version": "v7.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/a49db6f0a5033aef5143295342f1c95521b075ff",
-                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4||^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "psr/cache": "^1.0||^2.0",
+                "psr/cache": "^2.0||^3.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0"
             },
             "suggest": {
                 "ext-sodium": "Support EdDSA (Ed25519) signatures",
-                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
             },
             "type": "library",
             "autoload": {
@@ -58,16 +61,16 @@
                 }
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
+            "homepage": "https://github.com/googleapis/php-jwt",
             "keywords": [
                 "jwt",
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.10.0"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
             },
-            "time": "2023-12-01T16:26:39+00:00"
+            "time": "2026-06-11T17:54:14+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -188,16 +191,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.43",
+            "version": "3.0.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02"
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/709ec107af3cb2f385b9617be72af8cf62441d02",
-                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
                 "shasum": ""
             },
             "require": {
@@ -278,7 +281,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.43"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
             },
             "funding": [
                 {
@@ -294,7 +297,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-14T21:12:59+00:00"
+            "time": "2026-04-27T07:02:15+00:00"
         }
     ],
     "packages-dev": [

--- a/constants.php
+++ b/constants.php
@@ -4,8 +4,12 @@ if (!defined('ABSPATH')) {
 }
 
 define( 'PLUGIN_CULQI_URL' , plugin_dir_url(__FILE__) );
+
+define( 'PLUGIN_CULQI_PATH', plugin_dir_path(__FILE__) );
+
 define( 'CULQI_API_URL' , 'https://ag-online.culqi.com/gateway/' );
 define( 'CULQI_CONFIG_URL' , 'https://configonlineplatform.culqi.com' );
+
 define( 'EXPIRATION_TIME' , 24 );
 define( 'PLUGIN_VERSION', 'v4.0.1');
 define( 'PROCESSING', 'processing');
@@ -15,3 +19,4 @@ define( 'LIVE', 'live');
 define( 'CHECKOUT_VERSION', 'custom_checkout');
 define( 'CULQI_3DS', 'culqi_3ds');
 define( 'CULQI_DEBUG', false);
+

--- a/constants.php
+++ b/constants.php
@@ -11,7 +11,7 @@ define( 'CULQI_API_URL' , 'https://ag-online.culqi.com/gateway/' );
 define( 'CULQI_CONFIG_URL' , 'https://configonlineplatform.culqi.com' );
 
 define( 'EXPIRATION_TIME' , 24 );
-define( 'PLUGIN_VERSION', 'v4.0.1');
+define( 'PLUGIN_VERSION', 'v4.1.0');
 define( 'PROCESSING', 'processing');
 define( 'PLATFORM', 'woocommerce');
 define( 'TEST', 'test');

--- a/includes/block-support/class-culqi-block.php
+++ b/includes/block-support/class-culqi-block.php
@@ -1,27 +1,24 @@
 <?php
+/**
+ * Registra Culqi_Integration en el PaymentMethodRegistry de WooCommerce Blocks.
+ *
+ * La clase Culqi_Block anterior tenía lógica duplicada: instanciaba
+ * Culqi_Integration dos veces (en register_payment_method y en init_integration)
+ * y usaba dos hooks distintos para lo mismo. Este archivo hace solo lo necesario.
+ *
+ * @package Culqi
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+
 use Culqi\Culqi_Integration;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
-class Culqi_Block {
-    private static $initialized = false;
 
-    public function __construct() {
-        add_action('woocommerce_blocks_payment_method_type_registration', [ $this, 'register_payment_method' ]);
-        add_action('woocommerce_blocks_loaded', [ $this, 'init_integration' ]);
+add_action(
+    'woocommerce_blocks_payment_method_type_registration',
+    function ( PaymentMethodRegistry $payment_method_registry ) {
+        $payment_method_registry->register( new Culqi_Integration() );
     }
-    public function register_payment_method(PaymentMethodRegistry $payment_method_registry) {
-        $payment_method_registry->register(new Culqi_Integration());
-    }
-
-    public function init_integration() {
-        if (!self::$initialized) {
-            $integration = new Culqi_Integration();
-            $integration->initialize();
-            self::$initialized = true;
-        }
-    }
-}
-
-new Culqi_Block();
+);

--- a/includes/block-support/class-culqi-integration.php
+++ b/includes/block-support/class-culqi-integration.php
@@ -1,68 +1,122 @@
 <?php
+/**
+ * Integración de Culqi con el Block Checkout de WooCommerce.
+ *
+ * @package Culqi
+ */
 
 namespace Culqi;
 
-use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-class Culqi_Integration implements IntegrationInterface {
+final class Culqi_Integration extends AbstractPaymentMethodType {
 
     /**
-     * Returns the name of the integration.
+     * Debe coincidir exactamente con $this->id en WC_Gateway_Culqi.
      *
-     * @return string
+     * @var string
      */
-    public function get_name() {
-        return 'culqi';
+    protected $name = 'culqi';
+
+    /**
+     * Carga los settings del gateway desde la base de datos al inicializar el bloque
+     */
+    public function initialize(): void {
+        // woocommerce_culqi_settings es la opción que WooCommerce guarda
+        // automáticamente para el gateway con id 'culqi'.
+        $this->settings = get_option( 'woocommerce_culqi_settings', [] );
     }
 
     /**
-     * Initializes the integration.
-     *
-     * This is where you can register hooks or perform actions needed for the integration.
+     * Indica si el gateway está activo. El Block Checkout lo usa para
+     * decidir si mostrar Culqi como opción de pago.
      */
-    public function initialize() {
-       
+    public function is_active(): bool {
+        return ( $this->settings['enabled'] ?? 'no' ) === 'yes';
     }
 
     /**
-     * Registers the payment method with WooCommerce Blocks.
+     * Registra el script JS del block y retorna su handle.
+     * WooCommerce Blocks encola este script solo en páginas de checkout.
      *
-     * @param \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry
+     * @return string[]
      */
+    public function get_payment_method_script_handles(): array {
+        // @wordpress/scripts genera un .asset.php con versión y dependencias
+        // automáticas al hacer el build. Si no existe (sin bundler), se usan
+        // las dependencias manuales como fallback.
+        $asset_file = PLUGIN_CULQI_PATH . 'assets/js/culqi-block.asset.php';
+        $asset      = file_exists( $asset_file ) ? require $asset_file : [];
+        $version    = $asset['version'] ?? PLUGIN_VERSION;
+        $deps       = $asset['dependencies'] ?? [
+            'wc-blocks-registry',
+            'wc-settings',
+            'wp-element',
+            'wp-html-entities',
+        ];
 
-    /**
-     * Returns the script handles to be enqueued in the editor.
-     *
-     * @return array
-     */
-    public function get_editor_script_handles() {
+        wp_register_script(
+            'culqi-block',
+            PLUGIN_CULQI_URL . 'assets/js/culqi-block.js',
+            $deps,
+            $version,
+            true // cargar en footer
+        );
+
         return [ 'culqi-block' ];
     }
 
     /**
-     * Returns the script handles to be enqueued on the frontend.
+     * Datos que se exponen al JS del block.
+     * Accesibles en JS via: wc.wcSettings.getSetting('culqi_data')
      *
-     * @return array
+     * @return array<string, mixed>
      */
-    public function get_script_handles() {
-        return [ 'culqi-block' ];
-    }
+    public function get_payment_method_data(): array {
+        $config = culqi_get_config();
 
-    /**
-     * Returns additional data to be passed to the scripts.
-     *
-     * @return array
-     */
-    public function get_script_data() {
-        return [];
-    }
+        // Construir lista de íconos activos — misma lógica que get_icon()
+        // en WC_Gateway_Culqi para mantener consistencia visual.
+        $payment_methods = [];
+        if ( ! empty( $config->payment_methods ) ) {
+            $cleaned         = stripslashes( $config->payment_methods );
+            $payment_methods = json_decode( $cleaned, true ) ?? explode( ',', $config->payment_methods );
+        }
 
-    public function is_active() {
-        return (bool) get_option( 'culqi_enabled', false );
+        $icons = [];
+        if ( in_array( 'tarjeta', $payment_methods, true ) ) {
+            $icons[] = [
+                'id'  => 'cards',
+                'src' => PLUGIN_CULQI_URL . 'assets/images/cards.svg',
+                'alt' => 'Tarjetas',
+            ];
+        }
+        if ( in_array( 'yape', $payment_methods, true ) ) {
+            $icons[] = [
+                'id'  => 'yape',
+                'src' => PLUGIN_CULQI_URL . 'assets/images/yape.svg',
+                'alt' => 'Yape',
+            ];
+        }
+        if ( array_intersect( [ 'billetera', 'bancaMovil', 'agente', 'cuotealo' ], $payment_methods ) ) {
+            $icons[] = [
+                'id'  => 'pagoefectivo',
+                'src' => PLUGIN_CULQI_URL . 'assets/images/pagoefectivo.svg',
+                'alt' => 'PagoEfectivo',
+            ];
+        }
+
+        return [
+            'title'       => $this->get_setting( 'title', 'Culqi' ),
+            'description' => $this->get_setting( 'description', '' ),
+            'logo_url'    => PLUGIN_CULQI_URL . 'assets/images/culqi-logo.svg',
+            'icons'       => $icons,
+            'supports'    => $this->get_supported_features(),
+            'ajax_url'    => rest_url( 'culqi-api/get-payment-url/' ),
+        ];
     }
 }
-

--- a/includes/class-culqi-payment.php
+++ b/includes/class-culqi-payment.php
@@ -208,12 +208,23 @@ class WC_Gateway_Culqi extends WC_Payment_Gateway
             return;
         }
 
+        $is_block = isset($_POST['culqi_checkout_type']) && $_POST['culqi_checkout_type'] === 'block';
+
         $order->update_status('pending', __('Payment pending, redirecting to gateway.', 'culqi'));
+        $order->update_meta_data('_culqi_payment_url', $gateway_url);
         $order->save();
 
         $this->logger->info($this->logger_module, 'Order status updated to pending', [
             'order_id' => $order_id
         ]);
+
+        if ($is_block) {
+            return array(
+                'result' => 'success',
+                // Sin 'redirect' — WooCommerce Blocks no redirigirá.
+                // La URL se pasa via order meta + endpoint REST.
+            );
+        }
 
         return array(
             'result'     => 'success',

--- a/includes/functions/iframe-modal.php
+++ b/includes/functions/iframe-modal.php
@@ -1,8 +1,21 @@
 <?php
+/**
+ * Modal iframe de Culqi — compatible con Classic y Block Checkout.
+ *
+ * El hook woocommerce_before_checkout_form solo se dispara en el checkout
+ * clásico (shortcode). Para el Block Checkout se necesita un hook diferente.
+ *
+ * @package Culqi
+ */
+
 if (!defined('ABSPATH')) {
     exit;
 }
-add_action('woocommerce_before_checkout_form', 'culqi_custom_order_created_modal');
+
+/**
+ * Markup del modal. Reutilizado por ambos hooks.
+ * El iframe arranca con src="#" y gateway.js / culqi-block.js asignan la URL real.
+ */
 function culqi_custom_order_created_modal() {
     ?>
     <div id="order-created-modal" style="display:none;">
@@ -11,4 +24,20 @@ function culqi_custom_order_created_modal() {
         </div>
     </div>
     <?php
+}
+
+add_action('woocommerce_before_checkout_form', 'culqi_custom_order_created_modal');
+
+// Block Checkout
+// render_block_core_post_content se dispara al renderizar cualquier bloque en el contenido del post.
+add_action('wp_footer', 'culqi_inject_modal_for_blocks');
+function culqi_inject_modal_for_blocks() {
+    // Solo en páginas de checkout
+    if ( ! is_checkout() ) {
+        return;
+    }
+    if ( has_shortcode( get_post()->post_content ?? '', 'woocommerce_checkout' ) ) {
+        return;
+    }
+    culqi_custom_order_created_modal();
 }

--- a/includes/routes.php
+++ b/includes/routes.php
@@ -18,3 +18,33 @@ require_once plugin_dir_path(__FILE__) . 'functions/save-config.php';
 require_once plugin_dir_path(__FILE__) . 'functions/update-order.php';
 
 add_action('wp_ajax_culqi_get_config_url', 'culqi_get_config_url_ajax');
+
+// Endpoint para recuperar la URL de pago desde el Block Checkout
+function culqi_register_payment_url_endpoint() {
+    register_rest_route('culqi-api', '/get-payment-url/', [
+        'methods'             => 'GET',
+        'callback'            => 'culqi_get_payment_url',
+        'permission_callback' => '__return_true',
+    ]);
+}
+add_action('rest_api_init', 'culqi_register_payment_url_endpoint');
+
+function culqi_get_payment_url($request) {
+    $order_id = absint($request->get_param('order_id'));
+
+    $order = wc_get_order($order_id);
+    if (!$order) {
+        return new WP_Error('not_found', 'Order not found', array('status' => 404));
+    }
+
+    if ($order->get_status() !== 'pending') {
+        return new WP_Error('invalid_status', 'Order not in pending state', array('status' => 400));
+    }
+
+    $url = $order->get_meta('_culqi_payment_url', true);
+    if (empty($url)) {
+        return new WP_Error('no_url', 'No payment URL', array('status' => 404));
+    }
+
+    return rest_ensure_response(array('url' => $url));
+}

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: Culqi
 Plugin URI:https://wordpress.org/plugins/culqi-checkout
 Description: Culqi acepta pagos con tarjetas de débito y crédito, Yape, Cuotéalo BCP y PagoEfectivo (billeteras móviles, agentes y bodegas).
-Version: 4.0.1
+Version: 4.1.0
 Author: Culqi
 Author URI: https://culqi.com/
 Developer: Culqi Team

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ Tested up to: 6.9
 Stable tag: 5.6
 Requires PHP: 7.4
 WC requires at least: 2.6.11
-WC tested up to: 3.0.0
+WC tested up to: 9.0.0
 */
 
 if (!defined('ABSPATH')) {
@@ -64,17 +64,19 @@ function culqi_gateway_init() {
         return;
     }
 
-    // Include the Culqi Payment Gateway Class
+    // Gateway clásico (shortcode checkout)
     require_once plugin_dir_path(__FILE__) . 'includes/class-culqi-payment.php';
-    require_once plugin_dir_path( __FILE__ ) . 'includes/block-support/class-culqi-integration.php';
-    require_once plugin_dir_path( __FILE__ ) . 'includes/block-support/class-culqi-block.php';
 
-    // Add the gateway to WooCommerce
+    // Integración con el Block Checkout
+    require_once plugin_dir_path(__FILE__) . 'includes/block-support/class-culqi-integration.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/block-support/class-culqi-block.php';
+
+    // Registrar el gateway con WooCommerce
     add_filter('woocommerce_payment_gateways', 'culqi_add_culqi_gateway');
 
     function culqi_add_culqi_gateway($methods)
     {
-        $methods[] = 'WC_Gateway_Culqi'; // Payment Gateway class
+        $methods[] = 'WC_Gateway_Culqi';
         return $methods;
     }
 }
@@ -87,7 +89,8 @@ add_action('before_woocommerce_init', function () {
     }
 
     if (class_exists(FeaturesUtil::class)) {
-        FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__);
+        // true = compatible con Cart/Checkout Blocks
+        FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
     }
 });
 
@@ -97,15 +100,3 @@ require_once plugin_dir_path(__FILE__) . 'includes/functions/disable-reduce-stoc
 
 // Loader
 require_once plugin_dir_path(__FILE__) . 'admin/loader.php';
-
-function culqi_enqueue_culqi_block() {
-    wp_enqueue_script(
-        'culqi-block',
-        plugins_url( 'assets/js/culqi-block.js', __FILE__ ),
-        [ 'wp-element', 'wc-blocks-registry' ],
-        '1.0.0',
-        true
-    );
-}
-add_action( 'enqueue_block_editor_assets', 'culqi_enqueue_culqi_block' );
-add_action( 'wp_enqueue_scripts', 'culqi_enqueue_culqi_block' );

--- a/readme.es.txt
+++ b/readme.es.txt
@@ -4,7 +4,7 @@ Tags: culqi, checkout, payment method, Perú, woocommerce
 Donate link: https://culqi.com/
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 4.0.1
+Stable tag: 4.1.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -98,6 +98,12 @@ Sí, para trabajar con estas opciones de pago se requiere de ordenes de compra, 
 
 
 == Changelog ==
+
+= 4.1.0 =
+* Compatibilidad completa con WooCommerce Block Checkout (Cart/Checkout Blocks)
+* Iconos dinámicos de métodos de pago (tarjetas, Yape, PagoEfectivo) en block checkout
+* Endpoint REST API para recuperar URL de pago desde los metadatos del pedido
+* El modal iframe ahora funciona tanto en checkout clásico como en block
 
 = 4.0.1 =
 * Agregar script de build con ZIP versionado

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: culqi, checkout, payment method, woocommerce, peru
 Donate link: https://culqi.com/
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 4.0.1
+Stable tag: 4.1.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -89,6 +89,12 @@ Yes. These require purchase orders, which are generated automatically. You must 
 5. Webhook configuration
 
 == Changelog ==
+
+= 4.1.0 =
+* Full compatibility with WooCommerce Block Checkout (Cart/Checkout Blocks)
+* Dynamic payment method icons (cards, Yape, PagoEfectivo) in block checkout
+* REST API endpoint to retrieve payment URL from order meta for block checkout flow
+* iframe payment modal now works on both classic and block checkout
 
 = 4.0.1 =
 * Add build script with versioned ZIP output


### PR DESCRIPTION
* Compatibilidad completa con WooCommerce Block Checkout (Cart/Checkout Blocks)
* Iconos dinámicos de métodos de pago (tarjetas, Yape, PagoEfectivo) en block checkout
* Endpoint REST API para recuperar URL de pago desde los metadatos del pedido
* El modal iframe ahora funciona tanto en checkout clásico como en block
