### PR TITLE
Redirección post-pago y mejora en procesamiento de webhooks

### DIFF
--- a/assets/js/culqi-block.js
+++ b/assets/js/culqi-block.js
@@ -120,8 +120,9 @@
 
                 // Flujo principal: sin redirect, obtener URL via REST
                 if (orderId) {
-                    const url = settings.ajax_url + '?order_id=' + orderId;
-                    fetch(url)
+                    const paymentUrl = new URL(settings.ajax_url);
+                    paymentUrl.searchParams.append('order_id', orderId);
+                    fetch(paymentUrl.toString())
                         .then(function (r) { return r.json(); })
                         .then(function (data) {
                             if (data && data.url) {

--- a/includes/class-culqi-payment.php
+++ b/includes/class-culqi-payment.php
@@ -95,6 +95,10 @@ class WC_Gateway_Culqi extends WC_Payment_Gateway
         $order_key = $order->get_order_key();
         $shop_domain = get_site_url();
         $api_url = CULQI_API_URL . 'shopify/public/save-order';
+
+        $checkout_url = wc_get_checkout_url();
+        $success_url = wc_get_endpoint_url('order-received', $order_id, $checkout_url);
+        $success_url = add_query_arg('key', $order_key, $success_url);
         $platform = PLATFORM;
         $platform_version = PLUGIN_VERSION;
         $checkout_version = CHECKOUT_VERSION;
@@ -115,7 +119,8 @@ class WC_Gateway_Culqi extends WC_Payment_Gateway
             "payment_method" => array(
                 "type" => "offsite",
                 "data" => array(
-                    "cancel_url" => wc_get_checkout_url()
+                    "cancel_url" => wc_get_checkout_url(),
+                    "success_url" => $success_url
                 )
             ),
             "customer" => array(
@@ -148,6 +153,7 @@ class WC_Gateway_Culqi extends WC_Payment_Gateway
                 "locale" => "en-PE"
             ),
             "cancel_url" => wc_get_checkout_url(),
+            "success_url" => $success_url,
             "merchant_locale" => "en-PE",
             "shop_domain" =>  str_replace(['http://', 'https://'], '', $shop_domain),
             "order_key" => $order_key,

--- a/includes/functions/update-order.php
+++ b/includes/functions/update-order.php
@@ -53,68 +53,91 @@ function culqi_update_order(WP_REST_Request $request) {
         $order_id = sanitize_text_field($data['orderId']);
         $status = sanitize_text_field($data['status']);
         $transaction_id = sanitize_text_field($data['transactionId']);
-        $note_order_text = "order";
+
+        $valid_statuses = ['pending', 'processing', 'completed', 'on-hold', 'cancelled', 'refunded', 'failed'];
+        if (!in_array($status, $valid_statuses, true)) {
+            culqi_log('warning', 'Invalid status from webhook', [
+                'status' => $status,
+                'order_id' => $order_id,
+            ]);
+            return new WP_REST_Response(['message' => 'Invalid status.'], 400);
+        }
+
         if (is_numeric($order_id) && $order_id > 0) {
             $order = wc_get_order($order_id);
 
             if ($order) {
-                culqi_log('info', 'Order found, updating status', [
-                    'order_id' => $order_id,
-                    'new_status' => $status,
-                ]);
-                $order->update_status($status, 'Order status updated.', true);
-                $order->add_order_note('Order status changed to ' . $status);
-                if(culqi_get_payment_type($transaction_id) == "charge") {
-                    if ($status !== "refunded"){
-                        $card_number = sanitize_text_field($data['cardNumber']) ?? '';
-                        $card_brand = sanitize_text_field($data['cardBrand']) ?? '';
-                        $reference_code = sanitize_text_field($data['referenceCode']) ?? '';
-                        $note_order_text = "charge";
-                        wc_reduce_stock_levels($order_id);
+                // Idempotencia: evitar reprocesar el mismo pago confirmado
+                if (in_array($status, ['processing', 'completed'], true)
+                    && $order->get_transaction_id() === $transaction_id
+                    && $order->is_paid()
+                ) {
+                    culqi_log('info', 'Order already paid with same transaction_id, skipping', [
+                        'order_id' => $order_id,
+                        'transaction_id' => $transaction_id,
+                    ]);
+                    return new WP_REST_Response(['message' => 'Order already processed.'], 200);
+                }
 
-                        culqi_log('info', 'Stock reduced for charge order', [
-                            'order_id' => $order_id,
-                            'transaction_id' => $transaction_id,
-                        ]);
-                        $note_order_text = 'Culqi Charge Created:' . "\n" .
+                if (in_array($status, ['processing', 'completed'], true)) {
+                    // Pago confirmado: usar payment_complete() para setear
+                    // transaction_id, date_paid, hooks nativos y nota estándar.
+                    // payment_complete() requiere que la orden ya esté en
+                    // processing/completed. Como venimos de 'pending',
+                    // primero transicionamos el estado y persistimos.
+                    culqi_log('info', 'Payment confirmed, using payment_complete()', [
+                        'order_id' => $order_id,
+                        'transaction_id' => $transaction_id,
+                        'status' => $status,
+                    ]);
+
+                    $order->set_status($status);
+                    $order->save();
+                    $order->payment_complete($transaction_id);
+
+                    // Notas de auditoría de Culqi (payment_complete no las escribe)
+                    if (culqi_get_payment_type($transaction_id) === 'charge') {
+                        $card_number = sanitize_text_field($data['cardNumber'] ?? '');
+                        $card_brand = sanitize_text_field($data['cardBrand'] ?? '');
+                        $reference_code = sanitize_text_field($data['referenceCode'] ?? '');
+                        $order->add_order_note(
+                            'Culqi Charge:' . "\n" .
                             'Id: ' . $transaction_id . "\n" .
                             'Tarjeta: ' . $card_number . "\n" .
                             'Marca: ' . $card_brand . "\n" .
-                            'Cod. Referencia: ' . $reference_code;
-
-                        // Add the order note
-                        $order->add_order_note($note_order_text);
+                            'Cod. Referencia: ' . $reference_code
+                        );
                     }
-                } else {
-                    culqi_log('info', 'Processing order payment', [
-                        'transaction_id' => $transaction_id,
+
+                } elseif ($status === 'pending') {
+                    culqi_log('info', 'Pending payment, using update_status()', [
                         'order_id' => $order_id,
+                        'transaction_id' => $transaction_id,
                     ]);
-                    if ($status === "pending") {
-                        //$order->add_order_note('Culqi '. $note_order_text .' created: '. $transaction_id);
-                        $cip = sanitize_text_field($data['cip']) ?? '';
-                        $orderNumber = sanitize_text_field($data['orderNumber']) ?? '';
+                    $order->update_status('pending', 'Culqi order created.', true);
 
-                        culqi_log('info', 'CIP order created', [
-                            'order_id' => $order_id,
-                            'order_number' => $orderNumber,
-                            'cip' => $cip,
-                            'transaction_id' => $transaction_id,
-                        ]);
+                    $cip = sanitize_text_field($data['cip'] ?? '');
+                    $orderNumber = sanitize_text_field($data['orderNumber'] ?? '');
+                    $order->add_order_note(
+                        'Culqi Order Created:' . "\n" .
+                        'Id: ' . $transaction_id . "\n" .
+                        'CIP: ' . $cip . "\n" .
+                        'Order Number: ' . $orderNumber
+                    );
 
-                        $note_order_text = 'Culqi Order Created:' . "\n" .
-                            'Id: ' . $transaction_id . "\n" .
-                            'CIP: ' . $cip . "\n" .
-                            'Order Number: ' . $orderNumber;
+                } elseif ($status === 'refunded') {
+                    culqi_log('info', 'Refund processed, using update_status()', [
+                        'order_id' => $order_id,
+                        'transaction_id' => $transaction_id,
+                    ]);
+                    $order->update_status('refunded', 'Refund processed by Culqi.', true);
 
-                        $order->add_order_note($note_order_text);
-                    }
-                    if ($status === "processing" || $status === "completed") {
-                        wc_reduce_stock_levels($order_id);
-                        culqi_log('info', 'Stock reduced for order', [
-                            'order_id' => $order_id,
-                        ]);
-                    }
+                } else {
+                    culqi_log('info', 'Status change via update_status()', [
+                        'order_id' => $order_id,
+                        'status' => $status,
+                    ]);
+                    $order->update_status($status, 'Order status updated by Culqi.', true);
                 }
 
                 culqi_log('info', 'Webhook processed successfully', [
@@ -122,16 +145,20 @@ function culqi_update_order(WP_REST_Request $request) {
                     'final_status' => $status,
                 ]);
                 return new WP_REST_Response(['message' => 'Order status updated successfully.'], 200);
+            } else {
+                culqi_log('warning', 'Order not found for webhook update', [
+                    'order_id' => $order_id,
+                ]);
             }
         } else {
-            culqi_log('warning', 'Order not found for webhook update', [
+            culqi_log('warning', 'Invalid order_id from webhook', [
                 'order_id' => $order_id,
             ]);
         }
     }
 
     culqi_log('error', 'Webhook processing failed', [
-        'order_id' => $order_id ?? 'unknown',
+        'order_id' => $order_id,
     ]);
     return new WP_REST_Response(['message' => 'Error on update order status.'], 400);
 }


### PR DESCRIPTION
# Changelog

- Redirección correcta a la página de confirmación de pedido después del pago
- Corrección en la construcción de URLs del checkout para evitar errores cuando la URL ya contiene parámetros
- Uso de payment_complete() para pagos confirmados, activando correctamente los hooks nativos de WooCommerce (fecha de pago, transaction_id, reducción de stock)
- Protección contra procesamiento duplicado del mismo pago (idempotencia)
- Validación de estados inválidos en webhooks con rechazo automático
- Campos opcionales del webhook (número de tarjeta, CIP, etc.) ya no generan errores si faltan